### PR TITLE
AD-168144 Remove Duplicate Customer Records 

### DIFF
--- a/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
+++ b/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
@@ -44,7 +44,7 @@ SET		@endDateTime = DATEADD(MS, -1, DATEADD(D, 1, CONVERT(DATETIME2,@endDate)));
 							ORDER BY o.OutcomeEffectiveDate, o.LastModifiedDate, o.id) AS 'Rank'  -- we rank to remove duplicates
 
 		FROM				[dss-sessions] s
-		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId AND c.ReasonForTermination != 3
+		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId AND c.ReasonForTermination != 3 OR c.ReasonForTermination IS NULL
 		INNER JOIN			[dss-actionplans] ap							ON ap.SessionId = s.id
 		INNER JOIN			[dss-interactions] i							ON i.id = ap.InteractionId
 		INNER JOIN			[dss-outcomes] o								ON o.ActionPlanId = ap.id

--- a/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
+++ b/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
@@ -44,7 +44,7 @@ SET		@endDateTime = DATEADD(MS, -1, DATEADD(D, 1, CONVERT(DATETIME2,@endDate)));
 							ORDER BY o.OutcomeEffectiveDate, o.LastModifiedDate, o.id) AS 'Rank'  -- we rank to remove duplicates
 
 		FROM				[dss-sessions] s
-		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId AND c.ReasonForTermination != 3 OR c.ReasonForTermination IS NULL
+		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId
 		INNER JOIN			[dss-actionplans] ap							ON ap.SessionId = s.id
 		INNER JOIN			[dss-interactions] i							ON i.id = ap.InteractionId
 		INNER JOIN			[dss-outcomes] o								ON o.ActionPlanId = ap.id
@@ -58,6 +58,8 @@ SET		@endDateTime = DATEADD(MS, -1, DATEADD(D, 1, CONVERT(DATETIME2,@endDate)));
 		WHERE				o.OutcomeEffectiveDate	BETWEEN @startDate AND @endDateTime								-- effective between period start and end date and time
 		AND					o.OutcomeClaimedDate	BETWEEN @startDate AND @endDateTime								-- claimed between period start and end date and time
 		AND					o.TouchpointID = @touchpointId															-- for the touchpoint requesting the collection
+		AND c.ReasonForTermination != 3																				--Excludes duplicate customer records
+		OR c.ReasonForTermination IS NULL																			-- Allows Null value customer records
 	), dupesRemoved AS (
 		SELECT *
 		FROM TempData

--- a/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
+++ b/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
@@ -44,7 +44,7 @@ SET		@endDateTime = DATEADD(MS, -1, DATEADD(D, 1, CONVERT(DATETIME2,@endDate)));
 							ORDER BY o.OutcomeEffectiveDate, o.LastModifiedDate, o.id) AS 'Rank'  -- we rank to remove duplicates
 
 		FROM				[dss-sessions] s
-		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId
+		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId AND c.ReasonForTermination != 3
 		INNER JOIN			[dss-actionplans] ap							ON ap.SessionId = s.id
 		INNER JOIN			[dss-interactions] i							ON i.id = ap.InteractionId
 		INNER JOIN			[dss-outcomes] o								ON o.ActionPlanId = ap.id

--- a/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
+++ b/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
@@ -58,8 +58,7 @@ SET		@endDateTime = DATEADD(MS, -1, DATEADD(D, 1, CONVERT(DATETIME2,@endDate)));
 		WHERE				o.OutcomeEffectiveDate	BETWEEN @startDate AND @endDateTime								-- effective between period start and end date and time
 		AND					o.OutcomeClaimedDate	BETWEEN @startDate AND @endDateTime								-- claimed between period start and end date and time
 		AND					o.TouchpointID = @touchpointId															-- for the touchpoint requesting the collection
-		AND c.ReasonForTermination != 3																				--Excludes duplicate customer records
-		OR c.ReasonForTermination IS NULL																			-- Allows Null value customer records
+		AND (ReasonForTermination IS NULL OR ReasonForTermination <> 3)												--Excludes duplicate customer records
 	), dupesRemoved AS (
 		SELECT *
 		FROM TempData


### PR DESCRIPTION
As requested in the [[Ticket]](https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_boards/board/t/Live%20service%20Team/Stories/?workitem=168144) and [Documented Here](https://skillsfundingagency.atlassian.net/wiki/spaces/DFC/pages/4331962397/Removing+Duplicate+Records+from+the+Occupancy+and+Funding+Reports)

The Join the the Customer table `dss-customers` has been limted to only include records for NOT Duplicated Customer Record.
where duplicate Terminated records are identified as having the field `ReasonForTermination` = 3.

To exclude these records only records without 3 are included.
