### PR TITLE
Change the ranking order to descending in the SQL function dcc-collections

### DIFF
--- a/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
+++ b/NCS.DSS.StagingDatabase/dbo/Functions/dcc-collections.sql
@@ -41,7 +41,7 @@ SET		@endDateTime = DATEADD(MS, -1, DATEADD(D, 1, CONVERT(DATETIME2,@endDate)));
 								END
 							,DATEADD(mm, -12, CONVERT(DATE,s.DateandTimeOfSession)) AS 'PriorSessionDate'		
 							,RANK() OVER(PARTITION BY s.CustomerID, IIF(s.DateandTimeOfSession < @startDate,100,0 ), o.OutcomeType
-							ORDER BY o.OutcomeEffectiveDate, o.LastModifiedDate, o.id) AS 'Rank'  -- we rank to remove duplicates
+							ORDER BY o.OutcomeEffectiveDate DESC, o.LastModifiedDate DESC, o.id DESC) AS 'Rank'  -- we rank to remove duplicates
 
 		FROM				[dss-sessions] s
 		INNER JOIN			[dss-customers] c								ON c.id = s.CustomerId


### PR DESCRIPTION
Change the ranking order to descending in the SQL function dcc-collections. 
[User Story 227592](https://dev.azure.com/sfa-gov-uk/National%20Careers%20Service%20(NCS)/_workitems/edit/227592)