### PR TITLE
Remove "Digital" option from ActionPlanDeliveryMethod Reference data for ActionPlans

### DIFF
--- a/NCS.DSS.StagingDatabase/dbo/Stored Procedures/usp_CreateReferenceData.sql
+++ b/NCS.DSS.StagingDatabase/dbo/Stored Procedures/usp_CreateReferenceData.sql
@@ -65,7 +65,6 @@ BEGIN
 
 	INSERT INTO [dss-reference-data] ([Resource], [name], [key], [value], [description]) VALUES ('ActionPlans', 'ActionPlanDeliveryMethod', 'Paper', 1, 'Paper')
 	INSERT INTO [dss-reference-data] ([Resource], [name], [key], [value], [description]) VALUES ('ActionPlans', 'ActionPlanDeliveryMethod', 'Email', 2, 'Email')
-	INSERT INTO [dss-reference-data] ([Resource], [name], [key], [value], [description]) VALUES ('ActionPlans', 'ActionPlanDeliveryMethod', 'Digital', 3, 'Digital')
 	INSERT INTO [dss-reference-data] ([Resource], [name], [key], [value], [description]) VALUES ('ActionPlans', 'ActionPlanDeliveryMethod', 'Other', 99, 'Other')
 
 	INSERT INTO [dss-reference-data] ([Resource], [name], [key], [value], [description]) VALUES ('ActionPlans', 'PriorityCustomer', 'EighteenToTwentyfourNotInEducationEmploymentOrTraining', 1, '18 to 24 not in education, employment or training')


### PR DESCRIPTION
Following the decommissioning of Digital Action Plans from the NCS website, the 'Digital - 3' option needs removing for the ActionPlanDeliveryMethod field. The reference data for this option has been removed in this PR